### PR TITLE
can add tag to title as commandline parameter

### DIFF
--- a/distributions/cli.js
+++ b/distributions/cli.js
@@ -7,10 +7,27 @@ var _index2 = _interopRequireDefault(_index);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var reporter = (0, _index2.default)();
+var options = { passed: {}, failed: {} };
+
+var args = process.argv.slice(2);
+
+for (var i = 0; i < args.length; i++) {
+    var array = args[0].split('=');
+    switch (array[0]) {
+        case 'tag':
+            var tag = array[1];
+            options.passed.title = '[' + tag + '] Test passed.';
+            options.failed.title = '[' + tag + '] Test failed! ';
+            break;
+        default:
+            break;
+    }
+}
+
+var reporter = (0, _index2.default)(options);
 
 process.stdin.pipe(reporter).pipe(process.stdout);
 
 process.on('exit', function (status) {
-  if (status === 1 || reporter.isFailed) process.exit(1);
+    if (status === 1 || reporter.isFailed) process.exit(1);
 });

--- a/sources/cli.js
+++ b/sources/cli.js
@@ -2,7 +2,24 @@
 
 import createReporter from './index';
 
-const reporter = createReporter();
+const options = { passed: {}, failed: {} };
+
+const args = process.argv.slice(2);
+
+for(let i = 0; i < args.length; i++){
+    const array = args[0].split('=');
+    switch(array[0]){
+        case 'tag':
+            const tag = array[1];
+            options.passed.title = `[${tag}] Test passed.`;
+            options.failed.title = `[${tag}] Test failed! `;            
+            break;
+        default:
+            break;
+    }
+}
+
+const reporter = createReporter(options);
 
 process.stdin
   .pipe(reporter)


### PR DESCRIPTION
For the scenario where more than one set of tests being triggered (e.g. by a watch command for unit tests vs ui tests vs other kinds of tests), it's helpful to have a command line definable tag show up with the notification title.

E.g.  
[unit] Test passed.
[ui] Test failed!

The above would require the flag:
--tag=unit
--tag=ui