### PR TITLE
Handle failed test cases even when no diagnostic yaml is provided

### DIFF
--- a/distributions/index.js
+++ b/distributions/index.js
@@ -56,7 +56,7 @@ var createReporter = function createReporter() {
   p.on('assert', function (assert) {
     if (assert.ok) return;
 
-    errorOccuredAt = assert.diag.at;
+    errorOccuredAt = assert.diag && assert.diag.at;
   });
 
   p.on('complete', function (result) {

--- a/sources/index.js
+++ b/sources/index.js
@@ -30,7 +30,7 @@ const createReporter = ({ passed, failed } = {}) => {
   p.on('assert', assert => {
     if (assert.ok) return;
 
-    errorOccuredAt = assert.diag.at
+    errorOccuredAt = assert.diag && assert.diag.at
   });
 
   p.on('complete', result => {


### PR DESCRIPTION
Hey - love the package. I'm trying to use it with [Bats](https://github.com/bats-core/bats-core) and having some trouble because this tap producer includes no diagnostic yaml alongside failed test cases, which because of `errorOccuredAt = assert.diag.at;` results in
```
Uncaught TypeError: Cannot read property 'at' of undefined
```

Could the lib handle `assert.diag == undefined` gracefully as it does `assert.diag.at == undefined`?
```
message: `${result.fail || 0} of ${result.count} tests failed` +
                 (errorOccuredAt ? ` at ${errorOccuredAt}` : ''),
```